### PR TITLE
Feature/preserve artifact permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
 
 env:
+  # Match path used in `make generate` command
+  TEMPLATE_OUTPUT_DIR: my-app
   # Match name used in test.yml upload artifact step
   TEMPLATE_OUTPUT_ARTIFACT_NAME: template-output
 
@@ -90,7 +92,12 @@ jobs:
       - name: Extract downloaded artifact
         run: |
           tar -xzvf ${{ env.TEMPLATE_OUTPUT_ARTIFACT_NAME }}.tar.gz
+          mv ${{ env.TEMPLATE_OUTPUT_DIR }}/* .
+
+      - name: Clean up extracted artifact
+        run: |
           rm ${{ env.TEMPLATE_OUTPUT_ARTIFACT_NAME }}.tar.gz
+          rm -rf ${{ env.TEMPLATE_OUTPUT_DIR }}
 
       - name: List extracted files
         run: ls -la

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,10 @@ on:  # yamllint disable-line rule:truthy
     types: [completed]
   workflow_dispatch:
 
+env:
+  # Match name used in test.yml upload artifact step
+  TEMPLATE_OUTPUT_ARTIFACT_NAME: template-output
+
 permissions:
   contents: read
 
@@ -77,13 +81,18 @@ jobs:
       - name: Download artifact from "Test" workflow
         uses: actions/download-artifact@v4
         with:
-          # Match name used in test.yml upload artifact step
-          name: template-output
+          name: ${{ env.TEMPLATE_OUTPUT_ARTIFACT_NAME }}
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
           run-id: ${{ steps.get-run-id.outputs.run-id }}
 
-      - name: Show downloaded files
+      - name: List downloaded files
+        run: ls -la
+
+      - name: Extract downloaded artifact
+        run: tar -xzvf ${{ env.TEMPLATE_OUTPUT_ARTIFACT_NAME }}.tar.gz
+
+      - name: List extracted files
         run: ls -la
 
       - name: Setup git config

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,6 +65,9 @@ jobs:
           ref: 'main'
           token: ${{ secrets.TEMPLATE_OUTPUT_REPO_TOKEN }}
 
+      - name: Remove existing files
+        run: find . -mindepth 1 -maxdepth 1 -not -name '.git' -exec rm -rf {} \;
+
       # yamllint disable rule:line-length
       - name: Get run ID of "Test" workflow
         id: get-run-id

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy
 on:  # yamllint disable-line rule:truthy
   workflow_run:
     workflows: [Test]
-    branches: [feature/preserve-artifact-permissions]
+    branches: [main]
     types: [completed]
   workflow_dispatch:
 
@@ -55,6 +55,8 @@ jobs:
   deploy-generated-template:
     name: Deploy generated template
     runs-on: ubuntu-22.04
+    needs: [check-for-changes]
+    if: ${{ needs.check-for-changes.outputs.template-files-changed == 'true' }}
     steps:
       - name: Checkout output repository
         uses: actions/checkout@v4
@@ -112,5 +114,5 @@ jobs:
           export COMMIT_MESSAGE="Generated template from ${{ github.repository }}/${{ github.ref}}@${{ github.sha }}"
           git add .
           git commit -m "$COMMIT_MESSAGE"
-          git status
+          git push
       # yamllint enable rule:line-length

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy
 on:  # yamllint disable-line rule:truthy
   workflow_run:
     workflows: [Test]
-    branches: [main]
+    branches: [feature/preserve-artifact-permissions]
     types: [completed]
   workflow_dispatch:
 
@@ -55,8 +55,6 @@ jobs:
   deploy-generated-template:
     name: Deploy generated template
     runs-on: ubuntu-22.04
-    needs: [check-for-changes]
-    if: ${{ needs.check-for-changes.outputs.template-files-changed == 'true' }}
     steps:
       - name: Checkout output repository
         uses: actions/checkout@v4
@@ -106,5 +104,5 @@ jobs:
           export COMMIT_MESSAGE="Generated template from ${{ github.repository }}/${{ github.ref}}@${{ github.sha }}"
           git add .
           git commit -m "$COMMIT_MESSAGE"
-          git push
+          git status
       # yamllint enable rule:line-length

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,7 +88,9 @@ jobs:
         run: ls -la
 
       - name: Extract downloaded artifact
-        run: tar -xzvf ${{ env.TEMPLATE_OUTPUT_ARTIFACT_NAME }}.tar.gz
+        run: |
+          tar -xzvf ${{ env.TEMPLATE_OUTPUT_ARTIFACT_NAME }}.tar.gz
+          rm ${{ env.TEMPLATE_OUTPUT_ARTIFACT_NAME }}.tar.gz
 
       - name: List extracted files
         run: ls -la

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,8 +8,6 @@ on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
 
 env:
-  # Match path used in `make generate` command
-  TEMPLATE_OUTPUT_DIR: my-app
   # Match name used in test.yml upload artifact step
   TEMPLATE_OUTPUT_ARTIFACT_NAME: template-output
 
@@ -65,7 +63,7 @@ jobs:
           ref: 'main'
           token: ${{ secrets.TEMPLATE_OUTPUT_REPO_TOKEN }}
 
-      - name: Remove existing files
+      - name: Remove existing files except for .git directory
         run: find . -mindepth 1 -maxdepth 1 -not -name '.git' -exec rm -rf {} \;
 
       # yamllint disable rule:line-length
@@ -89,20 +87,18 @@ jobs:
           repository: ${{ github.repository }}
           run-id: ${{ steps.get-run-id.outputs.run-id }}
 
-      - name: List downloaded files
+      - name: List files
         run: ls -la
 
+      # yamllint disable rule:line-length
       - name: Extract downloaded artifact
-        run: |
-          tar -xzvf ${{ env.TEMPLATE_OUTPUT_ARTIFACT_NAME }}.tar.gz
-          mv -f ${{ env.TEMPLATE_OUTPUT_DIR }}/* .
+        run: tar -xzvf ${{ env.TEMPLATE_OUTPUT_ARTIFACT_NAME }}.tar.gz --strip-components=1
+      # yamllint enable rule:line-length
 
       - name: Clean up extracted artifact
-        run: |
-          rm ${{ env.TEMPLATE_OUTPUT_ARTIFACT_NAME }}.tar.gz
-          rm -rf ${{ env.TEMPLATE_OUTPUT_DIR }}
+        run: rm ${{ env.TEMPLATE_OUTPUT_ARTIFACT_NAME }}.tar.gz
 
-      - name: List extracted files
+      - name: List files
         run: ls -la
 
       - name: Setup git config

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Extract downloaded artifact
         run: |
           tar -xzvf ${{ env.TEMPLATE_OUTPUT_ARTIFACT_NAME }}.tar.gz
-          mv ${{ env.TEMPLATE_OUTPUT_DIR }}/* .
+          mv -f ${{ env.TEMPLATE_OUTPUT_DIR }}/* .
 
       - name: Clean up extracted artifact
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:  # yamllint disable-line rule:truthy
       - main
   workflow_dispatch:
 
+env:
+  # Match path used in `make generate` command
+  GENERATED_TEMPLATE_DIR: my-app
+
 permissions:
   contents: read
 
@@ -56,11 +60,14 @@ jobs:
       - name: Generate template from defaults
         run: make generate
 
+      - name: List generated files
+        run: ls -la ${{ env.GENERATED_TEMPLATE_DIR}}
+
       - name: Upload generated template
         uses: actions/upload-artifact@v4
         id: upload-generated-template
         with:
           # Match name used in deploy.yml download artifact step
           name: template-output
-          # Match path used in `make generate`
-          path: my-app
+          path: ${{ env.GENERATED_TEMPLATE_DIR}}
+          include-hidden-files: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,9 @@ on:  # yamllint disable-line rule:truthy
 
 env:
   # Match path used in `make generate` command
-  GENERATED_TEMPLATE_DIR: my-app
+  TEMPLATE_OUTPUT_DIR: my-app
+  # Match name used in deploy.yml download artifact step
+  TEMPLATE_OUTPUT_ARTIFACT_NAME: template-output
 
 permissions:
   contents: read
@@ -61,13 +63,17 @@ jobs:
         run: make generate
 
       - name: List generated files
-        run: ls -la ${{ env.GENERATED_TEMPLATE_DIR}}
+        run: ls -la ${{ env.TEMPLATE_OUTPUT_DIR}}
+
+      # yamllint disable rule:line-length
+      # Tar files before upload to preserve file permissions
+      - name: Tar files
+        run: tar -czvf ${{ env.TEMPLATE_OUTPUT_DIR}}.tar.gz ${{ env.TEMPLATE_OUTPUT_DIR}}
+      # yamllint enable rule:line-length
 
       - name: Upload generated template
         uses: actions/upload-artifact@v4
         id: upload-generated-template
         with:
-          # Match name used in deploy.yml download artifact step
-          name: template-output
-          path: ${{ env.GENERATED_TEMPLATE_DIR}}
-          include-hidden-files: true
+          name: ${{ env.TEMPLATE_OUTPUT_ARTIFACT_NAME }}
+          path: ${{ env.TEMPLATE_OUTPUT_DIR}}.tar.gz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
       # yamllint disable rule:line-length
       # Tar files before upload to preserve file permissions
       - name: Tar files
-        run: tar -czvf ${{ env.TEMPLATE_OUTPUT_DIR}}.tar.gz ${{ env.TEMPLATE_OUTPUT_DIR}}
+        run: tar -czvf ${{ env.TEMPLATE_OUTPUT_ARTIFACT_NAME}}.tar.gz ${{ env.TEMPLATE_OUTPUT_DIR}}
       # yamllint enable rule:line-length
 
       - name: Upload generated template
@@ -76,4 +76,4 @@ jobs:
         id: upload-generated-template
         with:
           name: ${{ env.TEMPLATE_OUTPUT_ARTIFACT_NAME }}
-          path: ${{ env.TEMPLATE_OUTPUT_DIR}}.tar.gz
+          path: ${{ env.TEMPLATE_OUTPUT_ARTIFACT_NAME}}.tar.gz


### PR DESCRIPTION
Tar the generated template artifact before upload to preserve the file permissions on the `run-tests.sh` script. Also cleans the cloned output repo in the deployment workflow to ensure that any files removed in the template are removed when pushed to the output repo.